### PR TITLE
Use rdkafka `curl-static` to fix a silent hang on macOS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ description = "Kafka client for NASA's General Coordinates Network (GCN)"
 categories = ["aerospace", "api-bindings", "science"]
 
 [dependencies]
-rdkafka = { version = "0.39.0", features = ["ssl", "curl", "zstd"] }
+rdkafka = { version = "0.39.0", features = ["ssl", "curl-static", "zstd"] }
 uuid = { version = "1.20.0", features = ["v4"] }
 
 [dev-dependencies]


### PR DESCRIPTION
When users build their consumer with `rdkafka` features `ssl-vendored` + `curl`, the binary ends up with two different libssl implementations at runtime: OpenSSL statically linked into the binary, plus a second libssl
loaded dynamically from system libcurl. `curl-static` builds libcurl against the same OpenSSL we link,
eliminating the mismatch.